### PR TITLE
Fix minimum heights of panels

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -180,7 +180,7 @@ a > .img-thumbnail:hover {
 }
 
 .min-height {
-  min-height: 420px;
+  min-height: 450px;
 }
 
 #particles-js {

--- a/css/style.css
+++ b/css/style.css
@@ -180,7 +180,7 @@ a > .img-thumbnail:hover {
 }
 
 .min-height {
-  min-height: 400px;
+  min-height: 420px;
 }
 
 #particles-js {


### PR DESCRIPTION
Left panel and right panel heights were uneven
because the right panel's content was larger than
the previous min-height of 400px. This commit fixes that.

Signed-off-by: Daniel Hong <daniel.hong@live.com>